### PR TITLE
Add error message if not DNS record could be found

### DIFF
--- a/pkg/dnsrequester.go
+++ b/pkg/dnsrequester.go
@@ -6,6 +6,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -59,7 +60,7 @@ func (resolveHandler *ResolveHandler) executeDNSRequest(session *discordgo.Sessi
 	} else {
 		return []*discordgo.MessageEmbedField{{
 			Name:   "Could not find DNS entry for question type",
-			Value:  strconv.Quote(dNSMessageTypeString),
+			Value:  strconv.Quote(strings.ToUpper(dNSMessageTypeString)),
 			Inline: true,
 		}}, false
 	}

--- a/pkg/dnsrequester.go
+++ b/pkg/dnsrequester.go
@@ -21,7 +21,7 @@ var dNSResponseCodeMessages = map[int]string{
 	dns.RcodeNameError:     "Non-Existent domain",
 }
 
-func (resolveHandler *ResolveHandler) executeDNSRequest(session *discordgo.Session, messageCreate *discordgo.MessageCreate, dNSMessageType uint16, domain string) (responseFields []*discordgo.MessageEmbedField, ok bool) {
+func (resolveHandler *ResolveHandler) executeDNSRequest(session *discordgo.Session, messageCreate *discordgo.MessageCreate, dNSMessageType uint16, dNSMessageTypeString string, domain string) (responseFields []*discordgo.MessageEmbedField, ok bool) {
 	// create new message instance from the parameter data
 	message := &dns.Msg{
 		Question: []dns.Question{{
@@ -48,12 +48,20 @@ func (resolveHandler *ResolveHandler) executeDNSRequest(session *discordgo.Sessi
 			Inline: true,
 		}}, false
 	}
-	responseFields = make([]*discordgo.MessageEmbedField, len(response.Answer))
-	for index, answer := range response.Answer {
-		responseFields[index] = &discordgo.MessageEmbedField{
-			Name:  answer.Header().Name,
-			Value: answer.String(),
+	if len(response.Answer) > 0 {
+		responseFields = make([]*discordgo.MessageEmbedField, len(response.Answer))
+		for index, answer := range response.Answer {
+			responseFields[index] = &discordgo.MessageEmbedField{
+				Name:  answer.Header().Name,
+				Value: answer.String(),
+			}
 		}
+	} else {
+		return []*discordgo.MessageEmbedField{{
+			Name:   "Could not find DNS entry for question type",
+			Value:  strconv.Quote(dNSMessageTypeString),
+			Inline: true,
+		}}, false
 	}
 	_, err = session.ChannelMessageSendEmbed(messageCreate.ChannelID, &discordgo.MessageEmbed{
 		Title:  resolveHandler.DiscordBotUser.Username,

--- a/pkg/handler.go
+++ b/pkg/handler.go
@@ -142,7 +142,7 @@ func (resolveHandler *ResolveHandler) handleMention(session *discordgo.Session, 
 			Inline: true,
 		}}, false
 	}
-	return resolveHandler.executeDNSRequest(session, messageCreate, messageType, domainName)
+	return resolveHandler.executeDNSRequest(session, messageCreate, messageType, messageTypeString, domainName)
 }
 
 func validateDNSMessageType(messageTypeString string) (messageType uint16, ok bool) {


### PR DESCRIPTION
This fixes bug #11 which deals with an empty message embed if no DNS record the requested DNS message type could be found.