### PR TITLE
Implement discordbots.org integration

### DIFF
--- a/cmd/discord1111resolver/main.go
+++ b/cmd/discord1111resolver/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 )
 
-var discordbotsUpdateURL = "https://discordbots.org/api/bots/%d/stats"
+var discordbotsUpdateURL = "https://discordbots.org/api/bots/%s/stats"
 
 var applicationName, version, branch, commit string
 
@@ -79,7 +79,7 @@ func main() {
 }
 
 type discordbotsUpdater struct {
-	*http.Client
+	http.Client
 	discordSession *discordgo.Session
 }
 


### PR DESCRIPTION
The service discordbots.org is a place where Discord bot developers can share their bots. The 1111Resolver can be found here: https://discordbots.org/bot/432969981366501396
This feature was requested in issue #19.